### PR TITLE
Agregando AronAcosta al archivo de contribuciones.

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -9,6 +9,7 @@ cesaloz
   cesaloz
   eucarys
 =[CesarGraterol](https://github.com/cdga2004)
+- [AronAcosta](https://github.com/dante-dacosta)
 - [Luis](https://github.com/LuisAngelLinarez)
 - [janet](https://github.com/Ja-n3t-777)
 - [angelo](https://github.com/angelolelli)


### PR DESCRIPTION
Carrera : Ing Telematica.
Universidad: Ucla
Estudiante: Aron Acosta 28.356.629